### PR TITLE
Add simple Pomodoro CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
-# chatgptdenemesi
-nodes
+# Pomodoro CLI App
+
+This repository contains a simple command-line Pomodoro timer written in Python.
+
+## Usage
+
+Run the application with:
+
+```bash
+python3 main.py
+```
+
+The timer starts a 25 minute work period followed by a 5 minute break. Each cycle repeats until you stop the program with `Ctrl+C`.

--- a/main.py
+++ b/main.py
@@ -1,1 +1,37 @@
-print("Pomodoro Uygulamasına Hoş Geldiniz!")
+import time
+
+WORK_MINUTES = 25
+BREAK_MINUTES = 5
+
+
+def countdown(seconds):
+    while seconds:
+        mins, secs = divmod(seconds, 60)
+        timer = f"{mins:02d}:{secs:02d}"
+        print(timer, end="\r", flush=True)
+        time.sleep(1)
+        seconds -= 1
+    print("00:00")
+
+
+def pomodoro_cycle(cycle_number):
+    print(f"\n--- Pomodoro {cycle_number} ---")
+    print("Work! Focus for 25 minutes.")
+    countdown(WORK_MINUTES * 60)
+    print("Break time! Relax for 5 minutes.")
+    countdown(BREAK_MINUTES * 60)
+    print("Cycle complete!")
+
+
+def main():
+    cycle = 1
+    try:
+        while True:
+            pomodoro_cycle(cycle)
+            cycle += 1
+    except KeyboardInterrupt:
+        print("\nExiting Pomodoro. Good work!")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement a command-line Pomodoro timer in `main.py`
- document how to run the timer in `README.md`

## Testing
- `python3 main.py` (stopped with Ctrl+C)

------
https://chatgpt.com/codex/tasks/task_e_686240136cb48320a562cc0e3a0a7225